### PR TITLE
Adding implementation for get_random_number()

### DIFF
--- a/source/to_be_ported.c
+++ b/source/to_be_ported.c
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016 ARM Limited. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ * Licensed under the Apache License, Version 2.0 (the License); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an AS IS BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stdint.h>
+#include <time.h>
+
+uint32_t get_random_number(void)
+{
+    return time(NULL);
+}


### PR DESCRIPTION
This is required by mbed-client-mbedtls module for application to
provide random number to mbedTLS functions.